### PR TITLE
Add modular AI companion scaffold with tool registry and Discord hooks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/build/
+/build-*/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.20)
+project(AstraAI LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+add_subdirectory(orchestrator)
+add_subdirectory(tools)

--- a/orchestrator/CMakeLists.txt
+++ b/orchestrator/CMakeLists.txt
@@ -1,0 +1,24 @@
+cmake_minimum_required(VERSION 3.20)
+project(Orchestrator LANGUAGES CXX)
+
+find_package(nlohmann_json CONFIG REQUIRED)
+find_package(dpp CONFIG QUIET)
+
+add_library(orchestrator_lib
+    src/tool_registry.cpp
+    src/discord_bot.cpp
+    src/pipeline.cpp
+)
+
+target_include_directories(orchestrator_lib PUBLIC include)
+
+target_link_libraries(orchestrator_lib PUBLIC nlohmann_json::nlohmann_json)
+if(dpp_FOUND)
+    target_link_libraries(orchestrator_lib PUBLIC dpp)
+else()
+    message(WARNING "D++ library not found. Discord features will be disabled.")
+endif()
+
+add_executable(orchestrator src/main.cpp)
+
+target_link_libraries(orchestrator PRIVATE orchestrator_lib)

--- a/orchestrator/include/discord_bot.hpp
+++ b/orchestrator/include/discord_bot.hpp
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <dpp/dpp.h>
+#include <unordered_map>
+#include "tool_registry.hpp"
+#include "pipeline.hpp"
+
+/**
+ * @brief Discord bot orchestrating text and voice interactions.
+ */
+class DiscordBot {
+public:
+    DiscordBot(const std::string& token, ToolRegistry& registry);
+
+    void run();
+
+private:
+    dpp::cluster bot_;
+    ToolRegistry& registry_;
+    PipelineManager pipelines_;
+    std::unordered_map<uint32_t, dpp::snowflake> ssrc_to_user_;
+
+    void setup_handlers();
+};

--- a/orchestrator/include/pipeline.hpp
+++ b/orchestrator/include/pipeline.hpp
@@ -1,0 +1,48 @@
+#pragma once
+
+#include <functional>
+#include <unordered_map>
+#include <vector>
+#include <mutex>
+#include <nlohmann/json.hpp>
+#include "tool_registry.hpp"
+
+/** Utterance JSON structure. */
+struct Utterance {
+    std::string user_id;
+    double t0;
+    double t1;
+    std::string text;
+};
+
+/**
+ * @brief Per-user processing pipeline.
+ */
+class UserPipeline {
+public:
+    UserPipeline(ToolRegistry& registry,
+                 std::function<void(const std::vector<int16_t>&)> send_audio);
+
+    void process_audio(const std::vector<int16_t>& pcm, const std::string& user_id);
+
+private:
+    ToolRegistry& registry_;
+    std::function<void(const std::vector<int16_t>&)> send_audio_;
+};
+
+/**
+ * @brief Manages pipelines for all users.
+ */
+class PipelineManager {
+public:
+    explicit PipelineManager(ToolRegistry& registry);
+
+    void on_audio_chunk(const std::string& user_id,
+                        const std::vector<int16_t>& pcm,
+                        std::function<void(const std::vector<int16_t>&)> send_audio);
+
+private:
+    ToolRegistry& registry_;
+    std::unordered_map<std::string, std::unique_ptr<UserPipeline>> pipelines_;
+    std::mutex mutex_;
+};

--- a/orchestrator/include/tool_interface.hpp
+++ b/orchestrator/include/tool_interface.hpp
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <nlohmann/json.hpp>
+
+/**
+ * @brief Interface for tools callable via the ToolRegistry.
+ */
+class ITool {
+public:
+    virtual ~ITool() = default;
+
+    /**
+     * @brief Call the tool with a JSON request.
+     * @param request JSON arguments.
+     * @return JSON response.
+     */
+    virtual nlohmann::json call(const nlohmann::json& request) = 0;
+};

--- a/orchestrator/include/tool_registry.hpp
+++ b/orchestrator/include/tool_registry.hpp
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <nlohmann/json.hpp>
+#include "tool_interface.hpp"
+
+/**
+ * @brief Registry of available tools.
+ */
+class ToolRegistry {
+public:
+    /** Register a tool by name. */
+    void register_tool(const std::string& name, std::shared_ptr<ITool> tool);
+
+    /** Call a registered tool. */
+    nlohmann::json call(const std::string& name, const nlohmann::json& request);
+
+private:
+    std::unordered_map<std::string, std::shared_ptr<ITool>> tools_;
+};

--- a/orchestrator/schemas/tool_call.schema.json
+++ b/orchestrator/schemas/tool_call.schema.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "ToolCall",
+  "type": "object",
+  "required": ["tool", "args"],
+  "properties": {
+    "tool": { "type": "string" },
+    "args": { "type": "object" }
+  },
+  "additionalProperties": false
+}

--- a/orchestrator/schemas/utterance.schema.json
+++ b/orchestrator/schemas/utterance.schema.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Utterance",
+  "type": "object",
+  "required": ["user_id", "t0", "t1", "text"],
+  "properties": {
+    "user_id": { "type": "string" },
+    "t0": { "type": "number" },
+    "t1": { "type": "number" },
+    "text": { "type": "string" }
+  },
+  "additionalProperties": false
+}

--- a/orchestrator/src/discord_bot.cpp
+++ b/orchestrator/src/discord_bot.cpp
@@ -1,0 +1,39 @@
+#include "discord_bot.hpp"
+
+#include <iostream>
+
+DiscordBot::DiscordBot(const std::string& token, ToolRegistry& registry)
+    : bot_(token), registry_(registry), pipelines_(registry_) {
+    setup_handlers();
+}
+
+void DiscordBot::setup_handlers() {
+    bot_.on_log(dpp::utility::cout_logger());
+
+    bot_.on_message_create([this](const dpp::message_create_t& event) {
+        if (event.msg.author.is_bot()) {
+            return;
+        }
+        // Echo text messages for now
+        bot_.message_create(dpp::message(event.msg.channel_id, event.msg.content));
+    });
+
+    bot_.on_voice_receive([this](const dpp::voice_receive_t& event) {
+        // Map SSRC to user id
+        ssrc_to_user_[event.audio.ssrc] = event.user_id;
+        std::vector<int16_t> pcm; // TODO: decode Opus frame to PCM
+        auto voice_client = event.from->get_voice();
+        if (!voice_client) {
+            return;
+        }
+        auto send_audio = [voice_client](const std::vector<int16_t>& pcm_out) {
+            // TODO: encode to Opus and send via voice_client->send_audio_raw
+            (void)pcm_out;
+        };
+        pipelines_.on_audio_chunk(std::to_string(event.user_id), pcm, send_audio);
+    });
+}
+
+void DiscordBot::run() {
+    bot_.start(dpp::st_wait);
+}

--- a/orchestrator/src/main.cpp
+++ b/orchestrator/src/main.cpp
@@ -1,0 +1,65 @@
+#include <cstdlib>
+#include <iostream>
+
+#include "discord_bot.hpp"
+#include "tool_registry.hpp"
+#include "tool_interface.hpp"
+
+/**
+ * @brief Simple ProcessTool that spawns a process per call and communicates over stdio.
+ */
+class ProcessTool : public ITool {
+public:
+    explicit ProcessTool(std::string exec_path) : exec_path_(std::move(exec_path)) {}
+
+    nlohmann::json call(const nlohmann::json& request) override {
+        // Very naive implementation using popen
+        std::string cmd = exec_path_;
+#ifdef _WIN32
+        FILE* pipe = _popen(cmd.c_str(), "w+");
+#else
+        FILE* pipe = popen(cmd.c_str(), "w+");
+#endif
+        if (!pipe) {
+            return nlohmann::json{{"error", "spawn_failed"}};
+        }
+        std::string req = request.dump();
+        fwrite(req.data(), 1, req.size(), pipe);
+        fflush(pipe);
+
+        char buffer[4096];
+        std::string response;
+        while (fgets(buffer, sizeof(buffer), pipe)) {
+            response += buffer;
+        }
+#ifdef _WIN32
+        _pclose(pipe);
+#else
+        pclose(pipe);
+#endif
+        if (response.empty()) {
+            return nlohmann::json{};
+        }
+        return nlohmann::json::parse(response, nullptr, false);
+    }
+
+private:
+    std::string exec_path_;
+};
+
+int main() {
+    const char* token = std::getenv("DISCORD_TOKEN");
+    if (!token) {
+        std::cerr << "DISCORD_TOKEN env var not set" << std::endl;
+        return 1;
+    }
+
+    ToolRegistry registry;
+    registry.register_tool("stt", std::make_shared<ProcessTool>("./stt_whisper"));
+    registry.register_tool("llm", std::make_shared<ProcessTool>("./llm_llama"));
+    registry.register_tool("tts", std::make_shared<ProcessTool>("./tts_piper"));
+
+    DiscordBot bot(token, registry);
+    bot.run();
+    return 0;
+}

--- a/orchestrator/src/pipeline.cpp
+++ b/orchestrator/src/pipeline.cpp
@@ -1,0 +1,40 @@
+#include "pipeline.hpp"
+
+#include <iostream>
+
+UserPipeline::UserPipeline(ToolRegistry& registry,
+                           std::function<void(const std::vector<int16_t>&)> send_audio)
+    : registry_(registry), send_audio_(std::move(send_audio)) {}
+
+void UserPipeline::process_audio(const std::vector<int16_t>& /*pcm*/, const std::string& user_id) {
+    // TODO: Implement VAD and buffering of PCM frames.
+    nlohmann::json stt_req = { {"user_id", user_id}, {"audio", "TODO"} };
+    nlohmann::json stt_resp = registry_.call("stt", stt_req);
+
+    Utterance utt{user_id, 0.0, 0.0, stt_resp.value("text", "")};
+    nlohmann::json llm_req = { {"utterance", { {"user_id", utt.user_id}, {"t0", utt.t0}, {"t1", utt.t1}, {"text", utt.text} }} };
+    nlohmann::json llm_resp = registry_.call("llm", llm_req);
+
+    if (llm_resp.value("tool", "") == "say") {
+        nlohmann::json tts_resp = registry_.call("tts", llm_resp["args"]);
+        // tts_resp expected to contain PCM16LE data in base64 or similar
+        // For now, just log and ignore audio content
+        std::vector<int16_t> pcm_out; // TODO: decode tts_resp
+        send_audio_(pcm_out);
+    }
+}
+
+PipelineManager::PipelineManager(ToolRegistry& registry)
+    : registry_(registry) {}
+
+void PipelineManager::on_audio_chunk(const std::string& user_id,
+                                     const std::vector<int16_t>& pcm,
+                                     std::function<void(const std::vector<int16_t>&)> send_audio) {
+    std::unique_lock<std::mutex> lock(mutex_);
+    auto& pipeline = pipelines_[user_id];
+    if (!pipeline) {
+        pipeline = std::make_unique<UserPipeline>(registry_, send_audio);
+    }
+    lock.unlock();
+    pipeline->process_audio(pcm, user_id);
+}

--- a/orchestrator/src/tool_registry.cpp
+++ b/orchestrator/src/tool_registry.cpp
@@ -1,0 +1,21 @@
+#include "tool_registry.hpp"
+
+#include <iostream>
+
+void ToolRegistry::register_tool(const std::string& name, std::shared_ptr<ITool> tool) {
+    tools_[name] = std::move(tool);
+}
+
+nlohmann::json ToolRegistry::call(const std::string& name, const nlohmann::json& request) {
+    auto it = tools_.find(name);
+    if (it == tools_.end()) {
+        std::cerr << "Tool not found: " << name << std::endl;
+        return nlohmann::json{ {"error", "tool_not_found"} };
+    }
+    auto& tool = it->second;
+    nlohmann::json response = tool->call(request);
+    // Log tool call
+    std::cout << "[ToolRegistry] " << name << " <= " << request.dump() << std::endl;
+    std::cout << "[ToolRegistry] " << name << " => " << response.dump() << std::endl;
+    return response;
+}

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -1,0 +1,13 @@
+cmake_minimum_required(VERSION 3.20)
+project(Tools LANGUAGES CXX)
+
+find_package(nlohmann_json CONFIG REQUIRED)
+
+add_executable(stt_whisper stt_whisper.cpp)
+target_link_libraries(stt_whisper PRIVATE nlohmann_json::nlohmann_json)
+
+add_executable(tts_piper tts_piper.cpp)
+target_link_libraries(tts_piper PRIVATE nlohmann_json::nlohmann_json)
+
+add_executable(llm_llama llm_llama.cpp)
+target_link_libraries(llm_llama PRIVATE nlohmann_json::nlohmann_json)

--- a/tools/llm_llama.cpp
+++ b/tools/llm_llama.cpp
@@ -1,0 +1,20 @@
+#include <iostream>
+#include <nlohmann/json.hpp>
+
+// Stub wrapper for llama.cpp LLM service producing tool calls.
+int main() {
+    nlohmann::json request;
+    if (!(std::cin >> request)) {
+        return 1;
+    }
+    // TODO: Implement llama.cpp inference with grammar-constrained JSON output
+    nlohmann::json response = {
+        {"tool", "say"},
+        {"args", {
+            {"text", "Hello world!"},
+            {"voice", "piper:en_US-amy"}
+        }}
+    };
+    std::cout << response.dump();
+    return 0;
+}

--- a/tools/stt_whisper.cpp
+++ b/tools/stt_whisper.cpp
@@ -1,0 +1,16 @@
+#include <iostream>
+#include <nlohmann/json.hpp>
+
+// Stub wrapper for whisper.cpp STT service.
+int main() {
+    nlohmann::json request;
+    if (!(std::cin >> request)) {
+        return 1;
+    }
+    // TODO: Implement whisper.cpp inference
+    nlohmann::json response = {
+        {"text", "stub transcription"}
+    };
+    std::cout << response.dump();
+    return 0;
+}

--- a/tools/tts_piper.cpp
+++ b/tools/tts_piper.cpp
@@ -1,0 +1,16 @@
+#include <iostream>
+#include <nlohmann/json.hpp>
+
+// Stub wrapper for Piper TTS service.
+int main() {
+    nlohmann::json request;
+    if (!(std::cin >> request)) {
+        return 1;
+    }
+    // TODO: Implement Piper TTS inference
+    nlohmann::json response = {
+        {"audio", "base64_pcm_stub"}
+    };
+    std::cout << response.dump();
+    return 0;
+}


### PR DESCRIPTION
## Summary
- Scaffold orchestrator in C++ with ToolRegistry, Discord bot skeleton, and JSON schemas
- Provide stub tools for Whisper STT, Llama LLM, and Piper TTS, wired via ProcessTool
- Outline voice -> VAD/STT -> LLM -> TTS pipeline for per-user processing

## Testing
- `cmake -S . -B build`
- `cmake --build build` *(fails: dpp/dpp.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b21635ed8883278300b464619e2e7c